### PR TITLE
fix: repository link in Quick Start pointing to evolving-agents-frame…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ A production-grade framework for creating, managing, and evolving AI agents with
 
 ```bash
 # Clone the repository
-git clone https://github.com/matiasmolinas/evolving-agents-framework.git
-cd evolving-agents-framework
+git clone https://github.com/matiasmolinas/evolving-agents.git
+cd evolving-agents
 
 # Install dependencies
 pip install -r requirements.txt


### PR DESCRIPTION
Following up on pull request https://github.com/matiasmolinas/evolving-agents/pull/20

the repo path is still not correct and fails to clone as the repo path is /evolving-agents.git instead of /evolving-agents-framework.git

this also require correcting the proceeding `cd` command.