### PR TITLE
fix: add missing import statement for ACPClient

### DIFF
--- a/evolving_agents/workflow/workflow_processor.py
+++ b/evolving_agents/workflow/workflow_processor.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Dict, Any, List, Optional, Tuple
 
 from evolving_agents.core.system_agent import SystemAgent
+from evolving_agents.acp.client import ACPClient
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Running `python examples/simplified_agent_communication.py` fails with below error due to missing import statement for ACPClient

```
WorkflowProcessor
    async def process_acp_workflow(self, workflow_yaml: str, acp_client: Optional[ACPClient] = None) -> Dict[str, Any]:
                                                                                  ^^^^^^^^^
NameError: name 'ACPClient' is not defined
```