### PR TITLE
Refactor: Migrate conversational form example to MongoDB

### DIFF
--- a/examples/forms/run_conversational_form.py
+++ b/examples/forms/run_conversational_form.py
@@ -10,6 +10,8 @@ from evolving_agents.core.system_agent import SystemAgentFactory
 from evolving_agents.core.llm_service import LLMService
 from evolving_agents.agent_bus.smart_agent_bus import SmartAgentBus
 from evolving_agents.core.dependency_container import DependencyContainer
+from evolving_agents.core.mongodb_client import MongoDBClient
+from datetime import datetime, timezone
 
 import os
 from dotenv import load_dotenv
@@ -32,15 +34,11 @@ async def create_conversational_form(form_prompt: str, form_id: str = "feedback_
         with open("form_library.json", "w") as f:
             f.write("[]")
     
-    smart_library = SmartLibrary("form_library.json", container=container)
+    smart_library = SmartLibrary(container=container)
     container.register('smart_library', smart_library)
     
     # Create agent bus with null system agent
-    agent_bus = SmartAgentBus(
-        storage_path="form_agent_bus.json",
-        log_path="form_agent_logs.json",
-        container=container
-    )
+    agent_bus = SmartAgentBus(container=container)
     container.register('agent_bus', agent_bus)
     
     # Create the system agent
@@ -50,6 +48,14 @@ async def create_conversational_form(form_prompt: str, form_id: str = "feedback_
     # Initialize components
     await smart_library.initialize()
     await agent_bus.initialize_from_library()
+    
+    # Get MongoDB Client
+    mongodb_client = container.get('mongodb_client')
+    if not mongodb_client:
+        mongodb_client = MongoDBClient() # Assumes MONGODB_URI and MONGODB_DATABASE_NAME are in .env
+        container.register('mongodb_client', mongodb_client)
+        
+    form_definitions_collection_name = "eat_form_definitions"
     
     # Create the architect agent using the container
     architect = await create_architect_zero(container=container)
@@ -130,13 +136,24 @@ async def create_conversational_form(form_prompt: str, form_id: str = "feedback_
             "FormSummaryGenerator"
         ]
     
-    # Save the form definition
-    with open(f"{form_id}_definition.json", "w") as f:
-        f.write(json.dumps({
-            "form_id": form_id,
-            "form_prompt": form_prompt,
-            "agents_used": agents_used
-        }, indent=2))
+    # Save the form definition to MongoDB
+    form_definition_data = {
+        "form_id": form_id,
+        "form_prompt": form_prompt,
+        "agents_used": agents_used,
+        "created_at": datetime.now(timezone.utc) # Store creation time
+    }
+    try:
+        form_definitions_collection = mongodb_client.get_collection(form_definitions_collection_name)
+        await form_definitions_collection.replace_one(
+            {"form_id": form_id}, 
+            form_definition_data, 
+            upsert=True
+        )
+        print(f"Form definition for {form_id} saved to MongoDB collection '{form_definitions_collection_name}'.")
+    except Exception as e:
+        print(f"Error saving form definition {form_id} to MongoDB: {e}")
+        # Optionally, re-raise or handle as appropriate for the application
     
     print(f"Form system design complete. Agents identified: {len(agents_used)}")
     
@@ -158,15 +175,11 @@ async def fill_out_form(form_id: str, user_responses: list):
     llm_service = LLMService(provider="openai", model="gpt-4o")
     container.register('llm_service', llm_service)
     
-    smart_library = SmartLibrary("form_library.json", container=container)
+    smart_library = SmartLibrary(container=container)
     container.register('smart_library', smart_library)
     
     # Create agent bus with null system agent
-    agent_bus = SmartAgentBus(
-        storage_path="form_agent_bus.json",
-        log_path="form_agent_logs.json",
-        container=container
-    )
+    agent_bus = SmartAgentBus(container=container)
     container.register('agent_bus', agent_bus)
     
     # Create the system agent
@@ -174,14 +187,38 @@ async def fill_out_form(form_id: str, user_responses: list):
     container.register('system_agent', system_agent)
     
     # Initialize components
+    
+    # Get MongoDB Client
+    mongodb_client = container.get('mongodb_client')
+    if not mongodb_client:
+        # This part might be redundant if create_conversational_form always runs first
+        # and registers the client. However, for robustness:
+        # from evolving_agents.core.mongodb_client import MongoDBClient # Ensure import if not already global
+        mongodb_client = MongoDBClient() 
+        container.register('mongodb_client', mongodb_client)
+        
+    form_responses_collection_name = "eat_form_responses"
+    form_definitions_collection_name = "eat_form_definitions" # Added this line
+    
     await smart_library.initialize()
     await agent_bus.initialize_from_library()
     
-    # Load the form definition
+    # Load the form definition from MongoDB
+    form_definition = None
     try:
-        with open(f"{form_id}_definition.json", "r") as f:
-            form_definition = json.load(f)
-    except FileNotFoundError:
+        # Ensure mongodb_client is available in this scope
+        # (It should be from the previous changes to fill_out_form)
+        form_definitions_collection = mongodb_client.get_collection(form_definitions_collection_name)
+        form_definition = await form_definitions_collection.find_one({"form_id": form_id})
+    except Exception as e:
+        print(f"Error retrieving form definition {form_id} from MongoDB: {e}")
+        return {
+            "status": "error",
+            "message": f"Database error retrieving form with ID {form_id}"
+        }
+
+    if not form_definition:
+        print(f"Form definition for {form_id} not found in MongoDB collection '{form_definitions_collection_name}'.")
         return {
             "status": "error",
             "message": f"Form with ID {form_id} not found"
@@ -231,13 +268,30 @@ async def fill_out_form(form_id: str, user_responses: list):
     
     summary_result = await system_agent.run(summary_prompt)
     
-    # Save the responses
-    with open(f"{form_id}_responses.json", "w") as f:
-        f.write(json.dumps({
-            "form_id": form_id,
-            "responses": all_results,
-            "summary": summary_result.result.text
-        }, indent=2))
+    # Save the responses to MongoDB
+    form_responses_data = {
+        "form_id": form_id,
+        "responses": all_results,
+        "summary": summary_result.result.text,
+        "submitted_at": datetime.now(timezone.utc) # Store submission time
+    }
+    try:
+        form_responses_collection = mongodb_client.get_collection(form_responses_collection_name)
+        # Using update_one with $push to append responses if the document exists, 
+        # or insert if it's new. This example assumes one document per form_id 
+        # that gets updated. If each submission should be a new document, use insert_one.
+        # For this case, let's assume we are replacing the whole response set for a given form_id
+        # if fill_out_form is called multiple times for the same form_id for simplicity,
+        # similar to how files were overwritten.
+        await form_responses_collection.replace_one(
+            {"form_id": form_id}, 
+            form_responses_data, 
+            upsert=True
+        )
+        print(f"Form responses for {form_id} saved to MongoDB collection '{form_responses_collection_name}'.")
+    except Exception as e:
+        print(f"Error saving form responses for {form_id} to MongoDB: {e}")
+        # Optionally, re-raise or handle as appropriate
     
     return {
         "status": "success",
@@ -247,6 +301,21 @@ async def fill_out_form(form_id: str, user_responses: list):
     }
 
 async def main():
+    # Initial setup for MongoDBClient in main for verification
+    # from evolving_agents.core.dependency_container import DependencyContainer # Already imported globally
+    # from evolving_agents.core.mongodb_client import MongoDBClient # Already imported globally
+    # from datetime import datetime, timezone # Already imported globally
+    
+    container = DependencyContainer()
+    try:
+        mongodb_client = MongoDBClient() # Assumes .env is configured
+        container.register('mongodb_client', mongodb_client)
+        print("MongoDBClient initialized in main for verification.")
+    except Exception as e:
+        print(f"Failed to initialize MongoDBClient in main for verification: {e}")
+        print("Please ensure MONGODB_URI and MONGODB_DATABASE_NAME are set in your .env file.")
+        mongodb_client = None # Set to None if initialization fails
+
     # Example 1: Customer Feedback Form
     feedback_form_prompt = """
     Create a customer feedback form for our restaurant with these questions:
@@ -270,6 +339,19 @@ async def main():
     
     print("Form Created!")
     print(f"Agents used: {form_result['agents_used']}")
+
+    if mongodb_client:
+        print("\n--- Verifying restaurant_feedback definition from MongoDB ---")
+        try:
+            form_defs_collection = mongodb_client.get_collection("eat_form_definitions")
+            definition = await form_defs_collection.find_one({"form_id": "restaurant_feedback"})
+            if definition:
+                print("Found definition in MongoDB:")
+                print(json.dumps(definition, indent=2, default=str)) # Use default=str for datetime
+            else:
+                print("Definition for restaurant_feedback not found in MongoDB.")
+        except Exception as e:
+            print(f"Error during MongoDB verification (definition): {e}")
     
     # Sample user responses to the form
     user_responses = [
@@ -290,6 +372,23 @@ async def main():
     print("\nForm Responses Processed!")
     print("Summary:")
     print(form_responses["summary"])
+
+    if mongodb_client:
+        print("\n--- Verifying restaurant_feedback responses from MongoDB ---")
+        try:
+            form_resps_collection = mongodb_client.get_collection("eat_form_responses")
+            responses_doc = await form_resps_collection.find_one({"form_id": "restaurant_feedback"})
+            if responses_doc:
+                print("Found responses in MongoDB:")
+                # Print a summary or part of the responses to avoid too much output
+                print(f"  Form ID: {responses_doc.get('form_id')}")
+                print(f"  Summary: {responses_doc.get('summary')[:200]}...") # Print first 200 chars of summary
+                print(f"  Response count: {len(responses_doc.get('responses', []))}")
+                print(f"  Submitted At: {responses_doc.get('submitted_at')}")
+            else:
+                print("Responses for restaurant_feedback not found in MongoDB.")
+        except Exception as e:
+            print(f"Error during MongoDB verification (responses): {e}")
     
     # Example 2: Job Application Form
     job_form_prompt = """
@@ -380,13 +479,10 @@ async def main():
     print(event_result["summary"])
     
     print("\n=== All forms processed successfully! ===")
-    print("Files created:")
-    print(f"  - restaurant_feedback_definition.json")
-    print(f"  - restaurant_feedback_responses.json")
-    print(f"  - job_application_definition.json")
-    print(f"  - job_application_responses.json")
-    print(f"  - event_registration_definition.json")
-    print(f"  - event_registration_responses.json")
+    print("Form definitions and responses are now stored in MongoDB.")
+    print("Relevant MongoDB collections (config dependent, typically):")
+    print(f"  - Form Definitions: eat_form_definitions")
+    print(f"  - Form Responses: eat_form_responses")
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Updates `examples/forms/run_conversational_form.py` to use MongoDB for data storage instead of JSON files, aligning with your project's unified MongoDB backend strategy.

Key changes:

-   **SmartLibrary/SmartAgentBus Initialization:** Modified `SmartLibrary` and `SmartAgentBus` instantiations to remove file path arguments, relying on `DependencyContainer` for MongoDB client configuration.
-   **Form Definitions Storage:**
    -   `create_conversational_form` now saves form definitions to the `eat_form_definitions` MongoDB collection.
    -   Includes a `created_at` timestamp.
-   **Form Responses Storage:**
    -   `fill_out_form` now saves form responses and summaries to the `eat_form_responses` MongoDB collection.
    -   Includes a `submitted_at` timestamp.
-   **Data Retrieval:**
    -   `fill_out_form` now retrieves form definitions from the `eat_form_definitions` MongoDB collection.
-   **Logging Update:** Updated print statements in `main` to reflect MongoDB storage.
-   **Basic Verification:** Added simple checks in `main` to retrieve and print data from MongoDB after creation/submission for one example, aiding in manual verification of the changes.

This migration enhances data management for the conversational forms example by leveraging your project's central MongoDB infrastructure.