### PR TITLE
Ship agentvcs to PyPI, and stop promising session merge

### DIFF
--- a/.github/workflows/release-agentvcs.yml
+++ b/.github/workflows/release-agentvcs.yml
@@ -1,0 +1,109 @@
+name: release-agentvcs
+
+# agentvcs was written, tested to 214 tests, given a release workflow and a
+# version number — and never published. `pip install agentvcs` returned 404 for
+# its entire life, which means the flagship of this organisation could not be
+# used by anyone who was not willing to clone a monorepo first.
+#
+# Publishing is therefore gated on the one thing a `twine check` does not prove:
+# that the artefact installs into an empty environment and the CLI actually
+# starts. The package claims zero runtime dependencies, so "installs with
+# nothing" is a property to enforce at release time, not a hope.
+#
+# Trigger by pushing a tag that names the package, because this is a monorepo
+# and packages/memory will want its own tag series later:
+#
+#     git tag agentvcs-v0.3.0 && git push origin agentvcs-v0.3.0
+
+on:
+  push:
+    tags: ["agentvcs-v*"]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        required: true
+        default: testpypi
+        type: choice
+        options: [testpypi, pypi]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/agentvcs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          pip install build twine
+          python -m build
+
+      - name: The tag must agree with the manifest
+        # A tag that says 0.4.0 over a pyproject that says 0.3.0 publishes 0.3.0
+        # under a release note for 0.4.0, and PyPI will not let you take it back.
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          manifest=$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          tagged="${GITHUB_REF_NAME#agentvcs-v}"
+          test "$manifest" = "$tagged" || {
+            echo "::error::tag $GITHUB_REF_NAME declares $tagged, pyproject declares $manifest"
+            exit 1
+          }
+
+      - name: Metadata renders on PyPI
+        run: twine check --strict dist/*
+
+      - name: The wheel installs into an empty environment and runs
+        # Not `pip install -e .` from the source tree: that quietly works even
+        # when the wheel is missing a data file. `agentvcs ui` shipped without
+        # its frontend once for exactly this reason.
+        run: |
+          python -m venv /tmp/clean
+          /tmp/clean/bin/pip install dist/*.whl
+          /tmp/clean/bin/agentvcs --version
+          /tmp/clean/bin/avcs --help > /dev/null
+          /tmp/clean/bin/python - <<'PY'
+          import importlib.resources as res
+          from agentvcs import mcp_server  # the MCP entrypoint the plugin spawns
+          assert res.files("agentvcs").joinpath("ui/index.html").is_file(), \
+              "the dashboard shipped without its single-page app"
+          print("clean install OK")
+          PY
+
+      - name: Nothing but the standard library came along
+        # The zero-dependency claim, checked against what pip actually resolved
+        # rather than against what pyproject.toml says.
+        run: |
+          installed=$(/tmp/clean/bin/pip list --format=freeze --exclude agentvcs \
+                      --exclude pip --exclude setuptools --exclude wheel)
+          test -z "$installed" || { echo "::error::pulled in: $installed"; exit 1; }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/agentvcs/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted Publishing: PyPI verifies this workflow's OIDC identity, so there
+    # is no API token in the repository to leak or rotate.
+    permissions:
+      id-token: write
+    environment:
+      name: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'testpypi' || 'pypi' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}

--- a/PLAN.md
+++ b/PLAN.md
@@ -83,6 +83,23 @@ been done. Until it is, this is not the part of the repository to sell.
 The repository had no workflows at all. It now runs every suite together on push
 and pull request: 222 tests that had never executed in the same place.
 
+## M4 · Distribution — **ready, one manual step outstanding**
+
+Worth stating as a milestone because its absence was invisible for a year: the
+flagship was never installable. `pip install agentvcs` returned 404 while the
+package had 214 tests, a version number and a release workflow in the repository
+it used to live in. Every reader who wanted to try it had to clone a monorepo
+first, which is most of the distance between this repository's 452 stars and
+agentvcs's one.
+
+`release-agentvcs.yml` builds on a `agentvcs-v*` tag and refuses to publish
+unless the wheel installs into an empty virtualenv, both console scripts start,
+the MCP entrypoint imports, the dashboard's frontend is present in the wheel, and
+pip resolved nothing outside the standard library.
+
+What is not done: the Trusted Publisher has to be registered on PyPI once, by
+hand, by someone with the account. Until then the workflow builds and stops.
+
 ## What is deliberately not planned
 
 **Re-implementing anything the SDK does.** Tools, the loop, permissions,

--- a/README.md
+++ b/README.md
@@ -26,16 +26,29 @@ transcript is plain JSONL that anyone can edit. Sessions persist the
 *conversation* — the skills, subagents, model and goal that produced it are not
 versioned alongside it.
 
-That gap is this repository.
+That gap is this repository. Most of it is closed; the last row is not, and it is
+the one worth being precise about.
 
 | | Agent SDK | This plugin |
 |---|---|---|
 | Branch a session | `fork` | — |
-| Compare two branches | — | `avcs_diff` |
-| Rejoin them | — | `avcs_merge`, with a `--reconcile` seam for goal and trace |
+| Snapshot code, goal, models and trace as one unit | — | `avcs_commit` |
+| Compare two snapshots | — | `avcs_diff`, per dimension |
+| Rejoin two snapshots | — | `avcs_merge`, with a `--reconcile` seam for goal and trace |
 | Refuse to ship a regression | — | `avcs_freeze`, which fails unless the eval passes |
 | Prove a transcript wasn't edited | — | Ed25519-signed commits |
 | Keep the trace past compaction | summarised away | archived by the `PreCompact` hook |
+| **Diff or merge two forked _sessions_** | — | **not yet — [M1](PLAN.md)** |
+
+The unit `avcs_diff` and `avcs_merge` operate on is an **agentvcs commit**, not an
+SDK session. Both work today, and neither will take two session IDs: a session is
+an append-only event log, and the adapter that turns one into something mergeable
+does not exist yet. Two forked sessions do share a prefix, so the common ancestor
+is findable — the open question is what a *conflict* means when both branches are
+conversations that reached different conclusions about the same file.
+
+That adapter is [M1](PLAN.md), it has not started, and it is the reason this
+repository exists rather than a detail of it.
 
 ## Install
 
@@ -56,7 +69,7 @@ ever stops being true.
 | | |
 |---|---|
 | [`plugin/`](plugin/) | The Agent SDK plugin: MCP server + three hooks |
-| [`packages/agentvcs/`](packages/agentvcs/) | The version control itself — 214 tests, no dependencies |
+| [`packages/agentvcs/`](packages/agentvcs/) | The version control itself — `pip install agentvcs`, 220 tests, no dependencies |
 | [`packages/memory/`](packages/memory/) | Structured recall above the SDK's flat `.claude/` memory files. Works; measures no better than naive matching — see [PLAN.md](PLAN.md) |
 | [`demos/robot/`](demos/robot/) | A 2D robot that evolves its own skills, versioned with agentvcs |
 | [`legacy/eat/`](legacy/eat/) | The Evolving Agents Toolkit, 2025. Kept readable; see below |
@@ -100,10 +113,10 @@ Claims here are measured, including the ones that came back flat.
 
 `pip install git+https://github.com/EvolvingAgentsLabs/evolving-agents` no longer
 installs an `evolving_agents` package — this is a monorepo now. Install what you
-want directly:
+want by name:
 
 ```bash
-pip install ./packages/agentvcs
+pip install agentvcs
 ```
 
 The 2025 package sits at `legacy/eat/` with its original `setup.py`, unchanged.

--- a/packages/agentvcs/README.md
+++ b/packages/agentvcs/README.md
@@ -1,7 +1,7 @@
 # agentvcs
 
 <p align="center">
-  <img src="docs/img/agentvcs.jpg" alt="Two branches diverge and merge, sealed once the eval passes" width="100%">
+  <img src="https://raw.githubusercontent.com/EvolvingAgentsLabs/evolving-agents/main/packages/agentvcs/docs/img/agentvcs.jpg" alt="Two branches diverge and merge, sealed once the eval passes" width="100%">
 </p>
 
 [![CI](https://github.com/EvolvingAgentsLabs/agentvcs/actions/workflows/ci.yml/badge.svg)](https://github.com/EvolvingAgentsLabs/agentvcs/actions/workflows/ci.yml)
@@ -33,7 +33,7 @@ the reasoning behind it.** The agent starts over.
 3. **Reconcile** the agent's run-time line back into your git releases instead of losing it.
 4. **Measure** whether the self-modification is actually improving — not just changing.
 
-It **complements** git — it doesn't replace it ([how it compares](docs/COMPARISON.md)). Git
+It **complements** git — it doesn't replace it ([how it compares](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/COMPARISON.md)). Git
 stays the system of record for what your team designs; agentvcs is the persistent episodic
 memory of what the agent became at run-time.
 
@@ -138,13 +138,13 @@ commit graph, with **no extra LLM calls**:
 The honest scope: these measure a population of variants across time — the object a **version
 control system** owns. Controller/fleet math (throughput control, sampling, scheduling)
 belongs to a live harness and is deliberately *out of scope*. Full derivations, mappings and
-the scope boundary: [`docs/EVOLUTIONARY_DYNAMICS.md`](docs/EVOLUTIONARY_DYNAMICS.md).
+the scope boundary: [`docs/EVOLUTIONARY_DYNAMICS.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/EVOLUTIONARY_DYNAMICS.md).
 
 ## Real demos
 
 Runnable, narrated, and on the web — every number comes from a real `agentvcs eval`, nothing
 faked. **[Live demos ↗](https://evolvingagentslabs.github.io/agentvcs/demos/)** ·
-reproduction guide [`docs/DEMOS.md`](docs/DEMOS.md).
+reproduction guide [`docs/DEMOS.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/DEMOS.md).
 
 - **Business cases — plain English, no math on screen**
   (`bash examples/business-cases/run.sh`). Five everyday situations, each ending in a
@@ -162,7 +162,7 @@ reproduction guide [`docs/DEMOS.md`](docs/DEMOS.md).
 - **The full agent loop** (`bash examples/agent-loop-demo/run.sh`). A simulated autonomous
   agent driving commit → eval → **rollback (with a recorded reason)** → freeze end to end.
 
-More in [`examples/README.md`](examples/README.md).
+More in [`examples/README.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/examples/README.md).
 
 ## Architecture & ecosystem
 
@@ -170,7 +170,7 @@ More in [`examples/README.md`](examples/README.md).
 for maximum auditability and drop-in integration. The data model underneath is a git-style
 content-addressed object store with typed objects (`commit` / `tree` / `goal` / `modelpin` /
 `trace` / `crystal`), a per-commit `fluid ↔ crystallized` state machine, and a three-way
-*semantic* merge over the merge-base ([`docs/SPEC.md`](docs/SPEC.md)). Model pins are
+*semantic* merge over the merge-base ([`docs/SPEC.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/SPEC.md)). Model pins are
 provider-agnostic (Anthropic, Google, Qwen, …); `"auto"` fills the pin from the model that
 actually ran, so it can't drift.
 
@@ -192,15 +192,26 @@ learns the workflow.
 (forge-proof provenance). Every verified `freeze` mints a **Soulbound Token**, building a
 verifiable CV of what the agent has actually proven — reputation that can't be cloned. Fleets
 are selected with DeSoc correlation discounting for maximum diversity. Full vision:
-[`docs/papers/souls-of-silicon.md`](docs/papers/souls-of-silicon.md). A separate opt-in
+[`docs/papers/souls-of-silicon.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/papers/souls-of-silicon.md). A separate opt-in
 **corporate/legal layer** (`agentvcs init --corporate`) adds an audit log and signed human
 approvals for governed deployments.
 
 ## Install
 
 ```bash
-git clone https://github.com/EvolvingAgentsLabs/agentvcs
-cd agentvcs && pip install -e .   # not on PyPI yet
+pip install agentvcs
+```
+
+Zero runtime dependencies — standard library only, with
+[a test](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/tests/test_zero_dependencies.py)
+that walks the AST and fails if that ever stops being true. Nothing is pulled in
+behind you.
+
+From source, inside the monorepo:
+
+```bash
+git clone https://github.com/EvolvingAgentsLabs/evolving-agents
+cd evolving-agents && pip install -e ./packages/agentvcs
 ```
 
 > `avcs` is a built-in shorthand for `agentvcs` — every command works with either name.
@@ -254,13 +265,13 @@ Declare the non-code dimensions in `agent.json`:
 
 - **Demos** — plain-English business stories + the technical companion:
   [live demos](https://evolvingagentslabs.github.io/agentvcs/demos/) ·
-  [`docs/DEMOS.md`](docs/DEMOS.md)
+  [`docs/DEMOS.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/DEMOS.md)
 - **The math & models** — derivations, mappings, scope boundary:
-  [`docs/EVOLUTIONARY_DYNAMICS.md`](docs/EVOLUTIONARY_DYNAMICS.md)
+  [`docs/EVOLUTIONARY_DYNAMICS.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/EVOLUTIONARY_DYNAMICS.md)
 - **How it compares** — next to git, LangSmith/Langfuse and MLflow/W&B, and what it is *not*:
-  [`docs/COMPARISON.md`](docs/COMPARISON.md)
-- **Tutorial / Spec / Agent contract** — [`docs/TUTORIAL.md`](docs/TUTORIAL.md) ·
-  [`docs/SPEC.md`](docs/SPEC.md) · [`docs/AGENT_MODE.md`](docs/AGENT_MODE.md)
+  [`docs/COMPARISON.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/COMPARISON.md)
+- **Tutorial / Spec / Agent contract** — [`docs/TUTORIAL.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/TUTORIAL.md) ·
+  [`docs/SPEC.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/SPEC.md) · [`docs/AGENT_MODE.md`](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/docs/AGENT_MODE.md)
 
 ## Scope
 
@@ -280,4 +291,4 @@ store has 5. 212 tests pass across Python 3.10–3.13.
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
+Apache-2.0. See [LICENSE](https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/LICENSE).

--- a/packages/agentvcs/pyproject.toml
+++ b/packages/agentvcs/pyproject.toml
@@ -18,13 +18,24 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
     "Topic :: Software Development :: Version Control",
 ]
 dependencies = []  # zero runtime dependencies — stdlib only, auditable by anyone
 
+# agentvcs is a directory of the evolving-agents monorepo, not its own repository.
+# The standalone EvolvingAgentsLabs/agentvcs repo is the pre-monorepo ancestor and
+# no longer receives commits; pointing PyPI at it would send every reader to a
+# stale tree.
 [project.urls]
-Homepage = "https://github.com/EvolvingAgentsLabs/agentvcs"
-Source = "https://github.com/EvolvingAgentsLabs/agentvcs"
+Homepage = "https://github.com/EvolvingAgentsLabs/evolving-agents"
+Source = "https://github.com/EvolvingAgentsLabs/evolving-agents/tree/main/packages/agentvcs"
+Documentation = "https://github.com/EvolvingAgentsLabs/evolving-agents/tree/main/packages/agentvcs/docs"
+Issues = "https://github.com/EvolvingAgentsLabs/evolving-agents/issues"
 
 [project.scripts]
 agentvcs = "agentvcs.cli:main"

--- a/packages/agentvcs/tests/test_packaging.py
+++ b/packages/agentvcs/tests/test_packaging.py
@@ -1,0 +1,100 @@
+"""The package stays publishable, enforced instead of remembered.
+
+agentvcs shipped 214 tests, a version number and a release workflow, and
+`pip install agentvcs` still returned 404 for its entire life. The lesson is not
+"remember to publish" — it is that packaging breaks silently, in ways no unit
+test notices, because nothing imports a README.
+
+Two failures this guards, both of which have already happened in this
+organisation:
+
+* `packages/memory` set `readme = "LICENSE"`. `pip install` died on a
+  content-type error and nobody found out until CI existed.
+* This README's links were written relative, which is correct on GitHub and
+  wrong on PyPI — where `docs/SPEC.md` resolves against `pypi.org` and 404s.
+  A reader who arrives from `pip install` would find every link broken.
+
+These read the manifest and the README as data. They do not build a wheel; the
+release workflow does that, and additionally installs it into an empty
+environment before it is allowed to publish.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+PACKAGE = Path(__file__).resolve().parent.parent
+PYPROJECT = tomllib.loads((PACKAGE / "pyproject.toml").read_text(encoding="utf-8"))
+PROJECT = PYPROJECT["project"]
+
+# `[label](target)` and `<img src="target">`, which is every way this README
+# points at something.
+MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+HTML_SRC = re.compile(r'src="([^"]+)"')
+
+# Fragments and mail links are resolved by the reader, not by the host.
+LOCAL_PREFIXES = ("#", "mailto:")
+
+
+def _readme_targets() -> list[str]:
+    text = (PACKAGE / PROJECT["readme"]).read_text(encoding="utf-8")
+    return MARKDOWN_LINK.findall(text) + HTML_SRC.findall(text)
+
+
+def test_the_declared_readme_exists() -> None:
+    """`readme = "LICENSE"` is how packages/memory became uninstallable."""
+    readme = PACKAGE / PROJECT["readme"]
+    assert readme.is_file(), f"pyproject declares readme = {PROJECT['readme']!r}, which is not a file"
+    assert readme.suffix == ".md", "the manifest advertises text/markdown; a non-.md readme will not render"
+
+
+def test_no_readme_link_is_relative() -> None:
+    """Relative links are correct on GitHub and 404 on PyPI. This is the PyPI copy."""
+    relative = [
+        target
+        for target in _readme_targets()
+        if not target.startswith(("http://", "https://")) and not target.startswith(LOCAL_PREFIXES)
+    ]
+    assert not relative, (
+        "these README links are relative, so they resolve against pypi.org and "
+        f"break on the package page: {relative}. Point them at "
+        "https://github.com/EvolvingAgentsLabs/evolving-agents/blob/main/packages/agentvcs/..."
+    )
+
+
+def test_the_readme_has_links_to_check() -> None:
+    """Guards the test above: an empty README would pass it vacuously."""
+    assert len(_readme_targets()) > 10, "expected the full README; found almost no links"
+
+
+def test_project_urls_point_at_the_monorepo() -> None:
+    """agentvcs is a directory of evolving-agents. The standalone repo is an ancestor.
+
+    PyPI renders these as the sidebar, so a stale URL sends every reader who
+    arrives from `pip install` to a tree that stopped receiving commits.
+    """
+    urls = PROJECT["urls"]
+    assert "Homepage" in urls and "Source" in urls, f"PyPI shows the sidebar from these: {sorted(urls)}"
+    stale = {name: url for name, url in urls.items() if "EvolvingAgentsLabs/agentvcs" in url}
+    assert not stale, f"these point at the pre-monorepo repository: {stale}"
+
+
+def test_the_zero_dependency_claim_is_in_the_manifest() -> None:
+    """test_zero_dependencies.py enforces the code side; this is the metadata side.
+
+    A dependency declared here but never imported would still be installed into
+    the user's environment, which is the property being sold.
+    """
+    assert PROJECT["dependencies"] == [], f"agentvcs advertises zero runtime dependencies, manifest says {PROJECT['dependencies']}"
+
+
+def test_every_console_script_resolves() -> None:
+    """A typo here builds and installs fine, then fails the first time it is run."""
+    import importlib
+
+    for name, target in PROJECT["scripts"].items():
+        module_name, _, function = target.partition(":")
+        module = importlib.import_module(module_name)
+        assert hasattr(module, function), f"console script {name!r} points at {target}, which does not exist"

--- a/packages/agentvcs/tests/test_packaging.py
+++ b/packages/agentvcs/tests/test_packaging.py
@@ -17,13 +17,27 @@ organisation:
 These read the manifest and the README as data. They do not build a wheel; the
 release workflow does that, and additionally installs it into an empty
 environment before it is allowed to publish.
+
+Reading the manifest needs `tomllib`, which is standard library only from 3.11.
+The package supports 3.10, so on that interpreter this module skips rather than
+grow a dependency for a metadata check. The CI matrix runs 3.10, 3.12 and 3.13
+against the same files, and the release workflow builds on 3.12 — so the
+properties below are still enforced on every push. What is lost on 3.10 is a
+duplicate run, not coverage.
 """
 
 from __future__ import annotations
 
 import re
-import tomllib
+import sys
 from pathlib import Path
+
+import pytest
+
+if sys.version_info < (3, 11):  # pragma: no cover - exercised by the 3.10 CI leg
+    pytest.skip("tomllib is stdlib from 3.11; checked on the 3.12 and 3.13 legs", allow_module_level=True)
+
+import tomllib
 
 PACKAGE = Path(__file__).resolve().parent.parent
 PYPROJECT = tomllib.loads((PACKAGE / "pyproject.toml").read_text(encoding="utf-8"))


### PR DESCRIPTION
Two changes, both about the same thing: the repository has 452 stars and the
package inside it has one. The gap is distribution and an over-claim — not code.

## 1. `pip install agentvcs` resolves

The flagship had 214 tests, a version number and a release workflow, and
returned 404 on PyPI for its entire life. Four things were in the way:

- `[project.urls]` pointed at `EvolvingAgentsLabs/agentvcs`, the pre-monorepo
  ancestor. PyPI renders those as the sidebar.
- All 14 README links were relative — correct on GitHub, 404 on PyPI, where
  `docs/SPEC.md` resolves against `pypi.org`.
- The install block said "not on PyPI yet".
- No release workflow existed in the monorepo.

`release-agentvcs.yml` publishes on an `agentvcs-v*` tag via Trusted Publishing
(no token in the repo), and refuses to publish unless the artefact survives what
`twine check` cannot test:

- the wheel installs into an **empty** virtualenv
- both console scripts start, and `agentvcs.mcp_server` — the entrypoint the
  plugin spawns — imports
- `ui/index.html` is actually in the wheel (it shipped without its frontend once)
- pip resolved **nothing** outside the standard library
- the tag version and the manifest version agree

`tests/test_packaging.py` keeps the metadata honest the same way
`test_zero_dependencies.py` keeps the imports honest. The relative-link guard was
verified by re-introducing a relative link and watching it fail, so it is not
passing vacuously.

## 2. The comparison table no longer promises session diff and merge

It put "Branch a session — `fork`" directly above "Compare two branches —
`avcs_diff`" and "Rejoin them — `avcs_merge`". The only available reading is that
the plugin diffs and merges two forked SDK sessions.

It does not. `PLAN.md` has said so since M1 was written: the adapter that turns a
session transcript into something mergeable has not started. Both tools are real
and their unit is an **agentvcs commit** — neither will take two session IDs.

The table now names the unit and carries a final row for what is missing, linked
to M1. That row is the reason the repository exists; it reads better than a table
that over-claims and gets found out on first use.

## Verification

- 220 tests pass (214 + 6 new)
- `twine check --strict` passes on both artefacts
- wheel installed into a clean venv: CLI starts, MCP entrypoint imports, UI asset
  present, zero transitive dependencies
- workflow YAML parses; every shell command in it was run locally first

## One manual step before this can publish

The PyPI Trusted Publisher must be registered once by hand, by whoever owns the
account — it cannot be done from here:

**PyPI → Publishing → Add a pending publisher**
- PyPI project name: `agentvcs`
- Owner: `EvolvingAgentsLabs` · Repository: `evolving-agents`
- Workflow: `release-agentvcs.yml` · Environment: `pypi`

Then `git tag agentvcs-v0.3.0 && git push origin agentvcs-v0.3.0`. Until that
exists the workflow builds, verifies and stops at the publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
