### PR TITLE
Freeze this repository

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,4 +1,35 @@
-# Plan
+# Plan — closed 2026-08-01
+
+**This plan is finished, not paused.** The repository is frozen; the work below
+either shipped or moved to [ai-os](https://github.com/EvolvingAgentsLabs/ai-os).
+
+Where each milestone ended:
+
+| | | |
+|---|---|---|
+| M0 · Bet on the SDK | **done** | Stands as written |
+| M1 · Merge across sessions | **moved to ai-os** | See below |
+| M2 · Structured memory | **measured flat** | Idea continues as `ai-storage` in ai-os |
+| M3 · CI | **done** | |
+| M4 · Distribution | **not done** | `agentvcs` was never published; PyPI's Trusted Publisher was never registered, so `pip install agentvcs` returns 404. Install from source |
+
+**On M1, honestly.** It was described here as "the reason this repo exists", and
+it never started. The diagnosis in it was right and is worth keeping: two forked
+sessions share a prefix, so finding the common ancestor is not the problem —
+deciding what a *conflict* is when both branches are conversations is.
+
+What was wrong was the substrate. An SDK session is an append-only event log with
+no declared goal and no parent pointer, so there is nothing to merge *onto*. In
+ai-os the unit of work is a flow — a persisted object that records
+`forkedFrom { flowId, atStep }` from its first commit — and diff comes before
+merge because diff stands alone.
+
+Read [`doc/03-ai-flows.md`](https://github.com/EvolvingAgentsLabs/ai-os/blob/main/doc/03-ai-flows.md)
+in ai-os. The original text of all four milestones follows, unedited.
+
+---
+
+# Plan (original, 2026-07-29)
 
 Four milestones. Two are done, one is blocked on a measurement that came back
 flat, and the one that justifies the repository has not started.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> **FROZEN — 2026-08-01.** Not under development. This repository is kept
+> because it is still true, not because it is maintained.
+>
+> The idea that justified it — versioning an agent's evolution so two branches
+> of work can be compared and rejoined — is carried forward in
+> **[ai-os](https://github.com/EvolvingAgentsLabs/ai-os)**, the organisation's
+> active project, as flow lineage. See
+> [`doc/03-ai-flows.md`](https://github.com/EvolvingAgentsLabs/ai-os/blob/main/doc/03-ai-flows.md).
+>
+> Last verified: 2026-08-01.
+
 # Evolving Agents
 
 <p align="center">
@@ -69,7 +80,7 @@ ever stops being true.
 | | |
 |---|---|
 | [`plugin/`](plugin/) | The Agent SDK plugin: MCP server + three hooks |
-| [`packages/agentvcs/`](packages/agentvcs/) | The version control itself — `pip install agentvcs`, 220 tests, no dependencies |
+| [`packages/agentvcs/`](packages/agentvcs/) | The version control itself — 220 tests, no dependencies. **Not on PyPI**; install from source |
 | [`packages/memory/`](packages/memory/) | Structured recall above the SDK's flat `.claude/` memory files. Works; measures no better than naive matching — see [PLAN.md](PLAN.md) |
 | [`demos/robot/`](demos/robot/) | A 2D robot that evolves its own skills, versioned with agentvcs |
 | [`legacy/eat/`](legacy/eat/) | The Evolving Agents Toolkit, 2025. Kept readable; see below |
@@ -115,8 +126,12 @@ Claims here are measured, including the ones that came back flat.
 installs an `evolving_agents` package — this is a monorepo now. Install what you
 want by name:
 
+`agentvcs` was never published to PyPI — the release workflow exists but its
+Trusted Publisher was never registered, so `pip install agentvcs` returns 404.
+Install from source:
+
 ```bash
-pip install agentvcs
+pip install "git+https://github.com/EvolvingAgentsLabs/evolving-agents#subdirectory=packages/agentvcs"
 ```
 
 The 2025 package sits at `legacy/eat/` with its original `setup.py`, unchanged.


### PR DESCRIPTION
This repository is frozen. Three things had to be true before archiving it, since
it is read-only afterwards and it is the organisation's only repository with real
reach:

1. **`PLAN.md` said M1 was "not started, and the reason this repo exists".**
   Freezing with that live leaves a repository whose own plan declares its
   purpose unfulfilled. The plan is now closed, with where each milestone ended
   and why M1's substrate was wrong. The original text is kept below the fold,
   unedited.
2. **`pip install agentvcs` returns 404** — verified, not assumed. The README
   promised it twice. It now says the package was never published and gives the
   source install that works.
3. **The header links to ai-os**, which is where the merge idea continues as flow
   lineage.